### PR TITLE
Fix firefox build

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -26,17 +26,34 @@ jobs:
       run: npm run build:chrome
       working-directory: Extension
 
-    - name: Rename extension file
-      run: mv packaged-extension.zip chrome.zip
+    - name: Build Firefox Extension
+      run: npm run build:firefox
       working-directory: Extension
 
-    - name: Upload Release Asset
-      id: upload-release-asset
+    - name: Rename extension files
+      run: |
+        mv packaged-extension.zip chrome.zip
+        cd build-firefox && zip -r ../firefox.zip . && cd ..
+      working-directory: Extension
+
+    - name: Upload Chrome Release Asset
+      id: upload-chrome-asset
       uses: actions/upload-release-asset@v1
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: Extension/chrome.zip
-        asset_name:  boost-debugger-chrome-extension.zip
+        asset_name: boost-debugger-chrome-extension.zip
+        asset_content_type: application/zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload Firefox Release Asset
+      id: upload-firefox-asset
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: Extension/firefox.zip
+        asset_name: boost-debugger-firefox-extension.zip
         asset_content_type: application/zip
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # web
 **/node_modules
 Extension/dist/*
+Extension/build-firefox/
 packaged-extension.zip
 extension-source.zip
 

--- a/Extension/README.md
+++ b/Extension/README.md
@@ -13,6 +13,7 @@ Continue the process with the steps listed below.
 
 ### Firefox
 
+- Run `npm run build:firefox`
 - Open Firefox's [debugging page](about:debugging#/runtime/this-firefox) (`about:debugging#/runtime/this-firefox`)
 - Click "Load Temporary Add-on..."
-- Navigate to this project's root and select `manifest.json`
+- Navigate to this project's root and select `build-firefox/manifest.json`

--- a/Extension/README.md
+++ b/Extension/README.md
@@ -13,7 +13,8 @@ Continue the process with the steps listed below.
 
 ### Firefox
 
+- Navigate to `Extension`
 - Run `npm run build:firefox`
 - Open Firefox's [debugging page](about:debugging#/runtime/this-firefox) (`about:debugging#/runtime/this-firefox`)
 - Click "Load Temporary Add-on..."
-- Navigate to this project's root and select `build-firefox/manifest.json`
+- Navigate to this project's root and select `Extension/build-firefox/manifest.json`

--- a/Extension/scripts/firefox-build.js
+++ b/Extension/scripts/firefox-build.js
@@ -1,27 +1,56 @@
 const fs = require('fs-extra');
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
-const zipper = require('zip-local');
 
 main();
 
 async function main() {
-  await exec('npm run build:chrome');
+  // Build the extension first
+  await exec('npm run build:prod');
 
-  // Removes non-source files
-  const tmpDir = '../tmp';
-  if (fs.existsSync(tmpDir)) {
-    await fs.rm(tmpDir, { recursive: true });
+  // Create Firefox build directory
+  const firefoxDir = 'build-firefox';
+  if (fs.existsSync(firefoxDir)) {
+    await fs.rm(firefoxDir, { recursive: true });
   }
-  await fs.mkdir(tmpDir);
-  await fs.move('node_modules', `${tmpDir}/node_modules`);
-  await fs.move('packaged-extension.zip', `${tmpDir}/packaged-extension.zip`);
+  await fs.mkdir(firefoxDir);
 
-  zipper.sync.zip('.').compress().save('extension-source.zip');
+  // Copy all files
+  const filesToCopy = ['_locales', 'dist', 'images', 'public'];
+  for (const filename of filesToCopy) {
+    if (fs.existsSync(filename)) {
+      await fs.copy(filename, `${firefoxDir}/${filename}`);
+    }
+  }
 
-  // Move project files back
-  await fs.move(`${tmpDir}/node_modules`, 'node_modules');
-  await fs.move(`${tmpDir}/packaged-extension.zip`, 'packaged-extension.zip');
+  // Read original manifest and convert to Firefox V2
+  const manifest = await fs.readJSON('manifest.json');
+  const firefoxManifest = {
+    manifest_version: 2,
+    name: manifest.name,
+    description: manifest.description,
+    version: manifest.version,
+    default_locale: manifest.default_locale,
+    icons: manifest.icons,
+    background: {
+      scripts: [manifest.background.service_worker || "dist/background.js"],
+      persistent: false
+    },
+    permissions: [
+      ...manifest.permissions,
+      ...(manifest.host_permissions || [])
+    ],
+    content_scripts: manifest.content_scripts,
+    browser_action: {
+      default_popup: manifest.action?.default_popup,
+      default_icon: manifest.action?.default_icon
+    },
+    options_ui: manifest.options_ui
+  };
 
-  console.log('Built for Firefox');
+  // Write Firefox manifest
+  await fs.writeJSON(`${firefoxDir}/manifest.json`, firefoxManifest, { spaces: 2 });
+  
+  console.log('✅ Firefox build created in build-firefox/ directory');
+  console.log('📁 Load build-firefox/ directory in Firefox');
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ What it can do:
 - check if different modules are working as expected;
 - easily force disable modules on a page.
 
-## Installation (Chrome, unpacked extension)
+## Installation
+
+### Chrome (unpacked extension)
+
 1. Head over to the [releases page](https://github.com/Automattic/boost-debugger/releases).
 2. On the latest release, download `boost-debugger-chrome-extension.zip`.
 3. Extract the zip file.
@@ -15,5 +18,15 @@ What it can do:
 6. Load the directory where you unpacked the extension in #3.
 7. Now open any site and use the extension from the toolbar to view the statuses. [screenshot](https://d.pr/i/vvjNZv)
 
-## (outdated) Installation (Chrome)
+### Chrome (outdated)
+
 [Download from Chrome Web Store](https://chromewebstore.google.com/detail/jetpack-boost-debugger/gjmbcbeedhhjlphdfldjbepeckgjalff)
+
+### Firefox
+
+1. Head over to the [releases page](https://github.com/Automattic/boost-debugger/releases).
+2. On the latest release, download `boost-debugger-firefox-extension.zip`.
+3. Extract the zip file.
+4. Open Firefox's [debugging page](about:debugging#/runtime/this-firefox) (`about:debugging#/runtime/this-firefox`).
+5. Click "Load Temporary Add-on...".
+6. Navigate to the place where you extracted the zip file and select `manifest.json`.


### PR DESCRIPTION
Fixes HOG-274

### Proposed changes

- Fix Firefox build;
- Hopefully update the workflow to support the Firefox as well.

### Testing instructions

- Follow the instructions in [`Extension/README.md`](https://github.com/Automattic/boost-debugger/blob/7f67e4f5829e221087c373f9a8e8de492d15170d/Extension/README.md#firefox) and make sure the extension works on Firefox browsers;
- You can also check the Chrome build to make sure it works as well.